### PR TITLE
Notes during memory use reduction

### DIFF
--- a/gconv_standalone.py
+++ b/gconv_standalone.py
@@ -262,6 +262,7 @@ class GConv(nn.Module):
         l_max=1,  # Maximum length of sequence. Fine if not provided: the kernel will keep doubling in length until longer than sequence. However, this can be marginally slower if the true length is not a power of 2
         channels=1,  # maps 1-dim to C-dim
         bidirectional=False,
+        conv_tile=None, # for lower ram situations, convolve only this much sequence at once
         # Arguments for FF
         activation='gelu',  # activation in between SS and FF
         ln=False,  # Extra normalization
@@ -301,6 +302,7 @@ class GConv(nn.Module):
         self.linear = linear
         self.mode = mode
         self.l_max = l_max
+        self.conv_tile = conv_tile
 
         # optional multiplicative modulation GLU-style
         # https://arxiv.org/abs/2002.05202
@@ -419,22 +421,21 @@ class GConv(nn.Module):
                         mode=interpolate_mode,
                     )[...,:output_size]
         elif 'cat' in self.mode:
-            k_offset = 0
+            k_i = 0
             for i in range(self.num_scales):
                 scale_factor = 2**(max(0, i-1)+self.init_scale)
                 input_size = self.kernel_dim
-                k_remaining = kernel_dim - k_offset
+                k_remaining = kernel_dim - k_i
                 if self.kernel_norm_initialized:
                     input_size = min(math.ceil(k_remaining / scale_factor) + 1, input_size)
                 output_size = min(k_remaining, input_size * scale_factor)
-                k_offset_next = k_offset + output_size
-                k[...,k_offset:k_offset_next] = F.interpolate(
+                k[...,k_i:k_i+output_size] = F.interpolate(
                         self.kernel_list[i][...,:input_size]
                          * multiplier ** (self.num_scales - i - 1),
                         scale_factor=scale_factor,
                         mode=interpolate_mode,
                     )[...,:output_size]
-                k_offset = k_offset_next
+                k_i += output_size
         else:
             raise ValueError(f"Unknown mode {self.mode}")
 
@@ -462,11 +463,29 @@ class GConv(nn.Module):
             k = F.pad(k0, (0, L)) \
                 + F.pad(k1.flip(-1), (L, 0)) \
 
-        k_f = torch.fft.rfft(k, n=2*L)  # (C H L)
-        u_f = torch.fft.rfft(u, n=2*L)  # (B H L)
-        # k_f.unsqueeze(-4) * u_f.unsqueeze(-3) # (B C H L)
-        y_f = contract('bhl,chl->bchl', u_f, k_f)
-        y = torch.fft.irfft(y_f, n=2*L)[..., :L]  # (B C H L)
+        conv_tile = self.conv_tile
+        if not self.conv_tile:
+            conv_tile = k.size(-1)
+
+        # Overlap-Add Algorithm for Tiled Convolution
+        y = torch.zeros( # (B C H L)
+            (u.size(0), self.channels, self.h, L),
+            dtype = u.dtype,
+            device = u.device
+        )
+        y_tile_max = conv_tile * 2 - 1
+        for k_i in range(0, k.size(-1), conv_tile):
+            k_tile = k[..., k_i : k_i + conv_tile]
+            k_f = torch.fft.rfft(k_tile, n=y_tile_max)  # (C H L)
+            # todo: the user could provide an offset to provide large u in chunks
+            for y_i in range(k_i, u.size(-1), conv_tile):
+                u_i = y_i - k_i
+                u_tile = u[..., u_i : u_i + conv_tile]
+                u_f = torch.fft.rfft(u_tile, n=y_tile_max)  # (B H L)
+                # k_f.unsqueeze(-4) * u_f.unsqueeze(-3) # (B C H L)
+                y_f = contract('bhl,chl->bchl', u_f, k_f)
+                y_tile = y[..., y_i : y_i + y_tile_max]
+                y_tile += torch.fft.irfft(y_f, n=y_tile_max)[..., : y_tile.size(-1)]
 
         # Compute D term in state space equation - essentially a skip connection
         y = y + contract('bhl,ch->bchl', u, self.D)


### PR DESCRIPTION
Hi,

For fun, kind of, I'm poking at reducing the memory usage of the standalone example, so more of it can run on my lower end system.

I've only skimmed the paper so far, but while looking at the code I'm encountering some small confusions or questions regarding the implementation, so I'm opening this pull request to connect a little bit.

I'll answer these questions myself when and if I find the answers.

Questions:

- I noticed the use of the kernel norm is detached from the gradient graph and cached between runs. How come this doesn't result in a disparate kernel norm as the kernels are updating during training?

- I noticed the use of `F.interpolate` does not specify `align_corners`, leaving it to default to False, which it looks like to me can leave some flat artefacts at the edges, and stretch the content between them by a subsample, when the interpolation is linear. Does this matter? My intuition would have been to do linear interpolation by dropping the last sample or wrapping to the first. In my changes, I had to add a constant of 1 to the input size to get the same interpolation output for truncated kernels.

- Why is it helpful to scale the weights of the kernels by their distance? Wouldn't the training process learn this scaling itself?

- Small changes to the backend can result in small (on the order of 1/100th) changes to outputs unless a lot of care is taken. How important is that kind of numerical stability?

Resolved:
- [x] I understand that `n=2*L` in the fft is to avoid performing the circular convolution. (this took me some learning)

Idea:
Given the principles of this algorithm, it looks to me like it might be possible to run using very minimal ram, by  using the fft to perform the kernel interpolation in frequency space, and streaming the convolution.